### PR TITLE
UPSTREAM: google/cadvisor: 1963: container: fix concurrent map acccess

### DIFF
--- a/container/crio/handler.go
+++ b/container/crio/handler.go
@@ -65,9 +65,6 @@ type crioContainerHandler struct {
 
 	ignoreMetrics container.MetricSet
 
-	// container restart count
-	restartCount int
-
 	reference info.ContainerReference
 
 	libcontainerHandler *containerlibcontainer.Handler
@@ -166,7 +163,10 @@ func newCrioContainerHandler(
 	// ignore err and get zero as default, this happens with sandboxes, not sure why...
 	// kube isn't sending restart count in labels for sandboxes.
 	restartCount, _ := strconv.Atoi(cInfo.Annotations["io.kubernetes.container.restartCount"])
-	handler.restartCount = restartCount
+	// Only adds restartcount label if it's greater than 0
+	if restartCount > 0 {
+		handler.labels["restartcount"] = strconv.Itoa(restartCount)
+	}
 
 	handler.ipAddress = cInfo.IP
 
@@ -210,10 +210,6 @@ func (self *crioContainerHandler) GetSpec() (info.ContainerSpec, error) {
 	spec, err := common.GetSpec(self.cgroupPaths, self.machineInfoFactory, self.needNet(), hasFilesystem)
 
 	spec.Labels = self.labels
-	// Only adds restartcount label if it's greater than 0
-	if self.restartCount > 0 {
-		spec.Labels["restartcount"] = strconv.Itoa(self.restartCount)
-	}
 	spec.Envs = self.envs
 	spec.Image = self.image
 


### PR DESCRIPTION
Needed so it is not dropped in the rebase
https://github.com/openshift/origin/pull/20033#discussion_r196149336

@runcom @deads2k 