### PR TITLE
[3.11] UPSTREAM: google/cadvisor: 2004: Check the length before using container.Stats

### DIFF
--- a/metrics/prometheus.go
+++ b/metrics/prometheus.go
@@ -889,6 +889,9 @@ func (c *PrometheusCollector) collectContainersInfo(ch chan<- prometheus.Metric)
 		}
 
 		// Now for the actual metrics
+		if len(container.Stats) == 0 {
+			continue
+		}
 		stats := container.Stats[0]
 		for _, cm := range c.containerMetrics {
 			if cm.condition != nil && !cm.condition(container.Spec) {


### PR DESCRIPTION
https://github.com/google/cadvisor/pull/2004

xref https://bugzilla.redhat.com/show_bug.cgi?id=1691023

@derekwaynecarr 