### PR TITLE
UPSTREAM: google/cadvisor: #2957, #2999; crio filter out systemd events, always evaluate raw factory last

### DIFF
--- a/container/crio/factory.go
+++ b/container/crio/factory.go
@@ -32,6 +32,9 @@ import (
 // The namespace under which crio aliases are unique.
 const CrioNamespace = "crio"
 
+// The namespace systemd runs components under.
+const SystemdNamespace = "system-systemd"
+
 // Regexp that identifies CRI-O cgroups
 var crioCgroupRegexp = regexp.MustCompile(`([a-z0-9]{64})`)
 
@@ -115,6 +118,9 @@ func (f *crioFactory) CanHandleAndAccept(name string) (bool, bool, error) {
 	}
 	if !strings.HasPrefix(path.Base(name), CrioNamespace) {
 		return false, false, nil
+	}
+	if strings.HasPrefix(path.Base(name), SystemdNamespace) {
+		return true, false, nil
 	}
 	// if the container is not associated with CRI-O, we can't handle it or accept it.
 	if !isContainerName(name) {

--- a/container/factory.go
+++ b/container/factory.go
@@ -203,7 +203,10 @@ func NewContainerHandler(name string, watchType watcher.ContainerWatchSource, in
 	defer factoriesLock.RUnlock()
 
 	// Create the ContainerHandler with the first factory that supports it.
-	for _, factory := range factories[watchType] {
+	// Note that since RawContainerHandler can support a wide range of paths,
+	// it's evaluated last just to make sure if any other ContainerHandler
+	// can support it.
+	for _, factory := range GetReorderedFactoryList(watchType) {
 		canHandle, canAccept, err := factory.CanHandleAndAccept(name)
 		if err != nil {
 			klog.V(4).Infof("Error trying to work out if we can handle %s: %v", name, err)
@@ -245,4 +248,27 @@ func DebugInfo() map[string][]string {
 		}
 	}
 	return out
+}
+
+// GetReorderedFactoryList returns the list of ContainerHandlerFactory where the
+// RawContainerHandler is always the last element.
+func GetReorderedFactoryList(watchType watcher.ContainerWatchSource) []ContainerHandlerFactory {
+	ContainerHandlerFactoryList := make([]ContainerHandlerFactory, 0, len(factories))
+
+	var rawFactory ContainerHandlerFactory
+	for _, v := range factories[watchType] {
+		if v != nil {
+			if v.String() == "raw" {
+				rawFactory = v
+				continue
+			}
+			ContainerHandlerFactoryList = append(ContainerHandlerFactoryList, v)
+		}
+	}
+
+	if rawFactory != nil {
+		ContainerHandlerFactoryList = append(ContainerHandlerFactoryList, rawFactory)
+	}
+
+	return ContainerHandlerFactoryList
 }

--- a/container/factory_test.go
+++ b/container/factory_test.go
@@ -160,3 +160,25 @@ func TestNewContainerHandler_Accept(t *testing.T) {
 		t.Error("Expected NewContainerHandler to ignore the container.")
 	}
 }
+
+func TestRawContainerHandler_Last(t *testing.T) {
+	chf1 := &mockContainerHandlerFactory{
+		Name: "raw",
+	}
+	container.RegisterContainerHandlerFactory(chf1, []watcher.ContainerWatchSource{watcher.Raw})
+	cfh2 := &mockContainerHandlerFactory{
+		Name: "crio",
+	}
+	container.RegisterContainerHandlerFactory(cfh2, []watcher.ContainerWatchSource{watcher.Raw})
+
+	cfh3 := &mockContainerHandlerFactory{
+		Name: "containerd",
+	}
+	container.RegisterContainerHandlerFactory(cfh3, []watcher.ContainerWatchSource{watcher.Raw})
+
+	list := container.GetReorderedFactoryList(watcher.Raw)
+
+	if list[len(list)-1].String() != "raw" {
+		t.Error("Expected raw container handler to be last in the list.")
+	}
+}


### PR DESCRIPTION
[google#2999](https://github.com/google/cadvisor/pull/2999)
[google#2957](https://github.com/google/cadvisor/pull/2957/)

xref: https://bugzilla.redhat.com/show_bug.cgi?id=1978528

cc: @harche