### PR TITLE
Cherry-pick s390x cpu topology

### DIFF
--- a/info/v1/machine.go
+++ b/info/v1/machine.go
@@ -53,6 +53,8 @@ type Core struct {
 	Caches       []Cache `json:"caches"`
 	UncoreCaches []Cache `json:"uncore_caches"`
 	SocketID     int     `json:"socket_id"`
+	BookID       string  `json:"book_id,omitempty"`
+	DrawerID     string  `json:"drawer_id,omitempty"`
 }
 
 type Cache struct {

--- a/machine/machine.go
+++ b/machine/machine.go
@@ -21,8 +21,6 @@ import (
 	"path"
 	"regexp"
 
-	// s390/s390x changes
-	"runtime"
 	"strconv"
 	"strings"
 
@@ -223,10 +221,6 @@ func GetMachineSwapCapacity() (uint64, error) {
 
 // GetTopology returns CPU topology reading information from sysfs
 func GetTopology(sysFs sysfs.SysFs) ([]info.Node, int, error) {
-	// s390/s390x changes
-	if isSystemZ() {
-		return nil, getNumCores(), nil
-	}
 	return sysinfo.GetNodesInfo(sysFs)
 }
 
@@ -289,16 +283,4 @@ func isRiscv64() bool {
 // mips64 changes
 func isMips64() bool {
 	return strings.Contains(machineArch, "mips64")
-}
-
-// s390/s390x changes
-func getNumCores() int {
-	maxProcs := runtime.GOMAXPROCS(0)
-	numCPU := runtime.NumCPU()
-
-	if maxProcs < numCPU {
-		return maxProcs
-	}
-
-	return numCPU
 }

--- a/utils/sysfs/fakesysfs/fake.go
+++ b/utils/sysfs/fakesysfs/fake.go
@@ -67,6 +67,12 @@ type FakeSysFs struct {
 	physicalPackageIDs   map[string]string
 	physicalPackageIDErr map[string]error
 
+	bookIDs   map[string]string
+	bookIDErr map[string]error
+
+	drawerIDs   map[string]string
+	drawerIDErr map[string]error
+
 	memTotal string
 	memErr   error
 
@@ -96,6 +102,14 @@ func (fs *FakeSysFs) GetCoreID(coreIDPath string) (string, error) {
 
 func (fs *FakeSysFs) GetCPUPhysicalPackageID(cpuPath string) (string, error) {
 	return fs.physicalPackageIDs[cpuPath], fs.physicalPackageIDErr[cpuPath]
+}
+
+func (fs *FakeSysFs) GetBookID(coreIDPath string) (string, error) {
+	return fs.bookIDs[coreIDPath], fs.bookIDErr[coreIDPath]
+}
+
+func (fs *FakeSysFs) GetDrawerID(coreIDPath string) (string, error) {
+	return fs.drawerIDs[coreIDPath], fs.drawerIDErr[coreIDPath]
 }
 
 func (fs *FakeSysFs) GetMemInfo(nodePath string) (string, error) {

--- a/utils/sysfs/fakesysfs/fake.go
+++ b/utils/sysfs/fakesysfs/fake.go
@@ -199,6 +199,16 @@ func (fs *FakeSysFs) SetPhysicalPackageIDs(physicalPackageIDs map[string]string,
 	fs.physicalPackageIDErr = physicalPackageIDErrors
 }
 
+func (fs *FakeSysFs) SetBookIDs(bookIDs map[string]string, bookIDErrors map[string]error) {
+	fs.bookIDs = bookIDs
+	fs.bookIDErr = bookIDErrors
+}
+
+func (fs *FakeSysFs) SetDrawerIDs(drawerIDs map[string]string, drawerIDErrors map[string]error) {
+	fs.drawerIDs = drawerIDs
+	fs.drawerIDErr = drawerIDErrors
+}
+
 func (fs *FakeSysFs) SetMemory(memTotal string, err error) {
 	fs.memTotal = memTotal
 	fs.memErr = err

--- a/utils/sysfs/sysfs.go
+++ b/utils/sysfs/sysfs.go
@@ -21,6 +21,7 @@ import (
 	"path"
 	"path/filepath"
 	"regexp"
+	"runtime"
 	"strconv"
 	"strings"
 
@@ -50,6 +51,8 @@ const (
 
 	coreIDFilePath    = "/" + sysFsCPUTopology + "/core_id"
 	packageIDFilePath = "/" + sysFsCPUTopology + "/physical_package_id"
+	bookIDFilePath    = "/" + sysFsCPUTopology + "/book_id"
+	drawerIDFilePath  = "/" + sysFsCPUTopology + "/drawer_id"
 
 	// memory size calculations
 
@@ -87,6 +90,10 @@ type SysFs interface {
 	GetCoreID(coreIDFilePath string) (string, error)
 	// Get physical package id for specified CPU
 	GetCPUPhysicalPackageID(cpuPath string) (string, error)
+	// Get book id for specified CPU
+	GetBookID(cpuPath string) (string, error)
+	// Get drawer id for specified CPU
+	GetDrawerID(cpuPath string) (string, error)
 	// Get total memory for specified NUMA node
 	GetMemInfo(nodeDir string) (string, error)
 	// Get hugepages from specified directory
@@ -162,6 +169,24 @@ func (fs *realSysFs) GetCPUPhysicalPackageID(cpuPath string) (string, error) {
 		return "", err
 	}
 	return strings.TrimSpace(string(packageID)), err
+}
+
+func (fs *realSysFs) GetBookID(cpuPath string) (string, error) {
+	bookIDFilePath := fmt.Sprintf("%s%s", cpuPath, bookIDFilePath)
+	bookID, err := os.ReadFile(bookIDFilePath)
+	if err != nil {
+		return "", err
+	}
+	return strings.TrimSpace(string(bookID)), err
+}
+
+func (fs *realSysFs) GetDrawerID(cpuPath string) (string, error) {
+	drawerIDFilePath := fmt.Sprintf("%s%s", cpuPath, drawerIDFilePath)
+	drawerID, err := os.ReadFile(drawerIDFilePath)
+	if err != nil {
+		return "", err
+	}
+	return strings.TrimSpace(string(drawerID)), err
 }
 
 func (fs *realSysFs) GetMemInfo(nodePath string) (string, error) {
@@ -365,22 +390,24 @@ func getCPUCount(cache string) (count int, err error) {
 
 func (fs *realSysFs) GetCacheInfo(cpu int, name string) (CacheInfo, error) {
 	cachePath := fmt.Sprintf("%s%d/cache/%s", cacheDir, cpu, name)
-	out, err := os.ReadFile(path.Join(cachePath, "/id"))
-	if err != nil {
-		return CacheInfo{}, err
-	}
 	var id int
-	n, err := fmt.Sscanf(string(out), "%d", &id)
-	if err != nil || n != 1 {
-		return CacheInfo{}, err
+	if runtime.GOARCH != "s390x" {
+		out, err := os.ReadFile(path.Join(cachePath, "/id"))
+		if err != nil {
+			return CacheInfo{}, err
+		}
+		n, err := fmt.Sscanf(string(out), "%d", &id)
+		if err != nil || n != 1 {
+			return CacheInfo{}, err
+		}
 	}
 
-	out, err = os.ReadFile(path.Join(cachePath, "/size"))
+	out, err := os.ReadFile(path.Join(cachePath, "/size"))
 	if err != nil {
 		return CacheInfo{}, err
 	}
 	var size uint64
-	n, err = fmt.Sscanf(string(out), "%dK", &size)
+	n, err := fmt.Sscanf(string(out), "%dK", &size)
 	if err != nil || n != 1 {
 		return CacheInfo{}, err
 	}

--- a/utils/sysfs/sysfs.go
+++ b/utils/sysfs/sysfs.go
@@ -177,7 +177,7 @@ func (fs *realSysFs) GetBookID(cpuPath string) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	return strings.TrimSpace(string(bookID)), err
+	return strings.TrimSpace(string(bookID)), nil
 }
 
 func (fs *realSysFs) GetDrawerID(cpuPath string) (string, error) {
@@ -186,7 +186,7 @@ func (fs *realSysFs) GetDrawerID(cpuPath string) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	return strings.TrimSpace(string(drawerID)), err
+	return strings.TrimSpace(string(drawerID)), nil
 }
 
 func (fs *realSysFs) GetMemInfo(nodePath string) (string, error) {


### PR DESCRIPTION
s390x CPU topology is missing in cadvisor which made kubelet service returns error when enabling CPU Manager. This patch adds missing CPU topology with which CPU Manager can also be enabled on s390x platform.
Please for review and if there are concerns let us know.