### PR TITLE
NO-JIRA: [release-4.17] UPSTREAM: google/cadvisor: 3582: fix network metrics collection logic

### DIFF
--- a/container/crio/handler.go
+++ b/container/crio/handler.go
@@ -148,13 +148,13 @@ func newCrioContainerHandler(
 		Namespace: CrioNamespace,
 	}
 
-	// Find out if we need network metrics reported for this container.
-	// Containers that don't have their own network -- this includes
-	// containers running in Kubernetes pods that use the network of the
-	// infrastructure container -- does not need their stats to be
-	// reported. This stops metrics being reported multiple times for each
-	// container in a pod.
-	metrics := common.RemoveNetMetrics(includedMetrics, cInfo.Labels["io.kubernetes.container.name"] != "POD")
+	// In a Kubernetes pod, all containers share the same network namespace.
+	// If the infrastructure container has empty network metrics, the CRI-O
+	// handler uses a running container in the pod to gather the necessary
+	// metrics. Therefore, it is essential to collect network metrics from
+	// all containers to ensure that if there is any running container in
+	// the pod, we capture the required network metrics for accurate reporting.
+	metrics := includedMetrics
 
 	libcontainerHandler := containerlibcontainer.NewHandler(cgroupManager, rootFs, cInfo.Pid, metrics)
 


### PR DESCRIPTION
This change modifies the logic for gathering network metrics in the CRI-O handler to ensure that metrics are collected from all containers. Since all containers share the same network namespace, gathering metrics from every container is crucial to account for scenarios where the infra container may have empty network metrics.

### Future improvements:
We can use a caching mechanism to maintain a designated container per pod. This cache will allow us to track which container to use for metrics collection efficiently. If the designated container dies, we should dynamically find another running container within the same pod.

```release-note
None
```