### PR TITLE
Backport pull request #3522 from clwluvw/hidden-device in cadvisor v0.51.0

### DIFF
--- a/utils/sysfs/sysfs.go
+++ b/utils/sysfs/sysfs.go
@@ -254,10 +254,8 @@ func (fs *realSysFs) IsBlockDeviceHidden(name string) (bool, error) {
 	if err != nil {
 		return false, fmt.Errorf("failed to read %s: %w", devHiddenPath, err)
 	}
-	if string(hidden) == "1" {
-		return true, nil
-	}
-	return false, nil
+
+	return strings.TrimSpace(string(hidden)) == "1", nil
 }
 
 func (fs *realSysFs) GetBlockDeviceScheduler(name string) (string, error) {


### PR DESCRIPTION
sysfs: trim spaces in device hidden check

(cherry picked from commit 96c346ed6af33ecc856f82dfd9ef6b0fd6b66949)

Backports https://github.com/google/cadvisor/pull/3522 from cadvisor v0.51.0.

This is needed to fix container_fs_ metrics on systems with multipath devices. Without it, errors like:

    Failed to get disk map: open /sys/block/nvme0c0n1/dev

will be logged, and cadvisor will emit nonsensical metrics with the label device="" for filesystem I/O.

See https://github.com/google/cadvisor/issues/3693 for full explanation.