### PR TITLE
OCPBUGS-57665: Pick upstream lock contention improvements

### DIFF
--- a/manager/manager.go
+++ b/manager/manager.go
@@ -573,19 +573,21 @@ func (m *manager) getContainer(containerName string) (*containerData, error) {
 }
 
 func (m *manager) getSubcontainers(containerName string) map[string]*containerData {
+	matchedName := path.Join(containerName, "/")
+
 	m.containersLock.RLock()
 	defer m.containersLock.RUnlock()
+
 	containersMap := make(map[string]*containerData, len(m.containers))
 
 	// Get all the unique subcontainers of the specified container
-	matchedName := path.Join(containerName, "/")
-	for i := range m.containers {
-		if m.containers[i] == nil {
+	for _, cont := range m.containers {
+		if cont == nil {
 			continue
 		}
-		name := m.containers[i].info.Name
+		name := cont.info.Name
 		if name == containerName || strings.HasPrefix(name, matchedName) {
-			containersMap[m.containers[i].info.Name] = m.containers[i]
+			containersMap[name] = cont
 		}
 	}
 	return containersMap

--- a/manager/manager.go
+++ b/manager/manager.go
@@ -191,7 +191,6 @@ func New(memoryCache *memory.InMemoryCache, sysfs sysfs.SysFs, HousekeepingConfi
 	eventsChannel := make(chan watcher.ContainerEvent, 16)
 
 	newManager := &manager{
-		containers:                            make(map[namespacedContainerName]*containerData),
 		quitChannels:                          make([]chan error, 0, 2),
 		memoryCache:                           memoryCache,
 		fsInfo:                                fsInfo,
@@ -246,8 +245,7 @@ type namespacedContainerName struct {
 }
 
 type manager struct {
-	containers               map[namespacedContainerName]*containerData
-	containersLock           sync.RWMutex
+	containers               sync.Map // namespacedContainerName -> *containerData
 	memoryCache              *memory.InMemoryCache
 	fsInfo                   fs.FsInfo
 	sysFs                    sysfs.SysFs
@@ -363,10 +361,15 @@ func (m *manager) Stop() error {
 }
 
 func (m *manager) destroyCollectors() {
-	for _, container := range m.containers {
+	m.containers.Range(func(_, value any) bool {
+		container := value.(*containerData)
+		if container == nil {
+			return true
+		}
 		container.perfCollector.Destroy()
 		container.resctrlCollector.Destroy()
-	}
+		return true
+	})
 }
 
 func (m *manager) updateMachineInfo(quit chan error) {
@@ -425,21 +428,12 @@ func (m *manager) globalHousekeeping(quit chan error) {
 }
 
 func (m *manager) getContainerData(containerName string) (*containerData, error) {
-	var cont *containerData
-	var ok bool
-	func() {
-		m.containersLock.RLock()
-		defer m.containersLock.RUnlock()
-
-		// Ensure we have the container.
-		cont, ok = m.containers[namespacedContainerName{
-			Name: containerName,
-		}]
-	}()
+	// Ensure we have the container.
+	v, ok := m.containers.Load(namespacedContainerName{Name: containerName})
 	if !ok {
 		return nil, fmt.Errorf("unknown container %q", containerName)
 	}
-	return cont, nil
+	return v.(*containerData), nil
 }
 
 func (m *manager) GetDerivedStats(containerName string, options v2.RequestOptions) (map[string]v2.DerivedStats, error) {
@@ -563,33 +557,29 @@ func (m *manager) containerDataToContainerInfo(cont *containerData, query *info.
 }
 
 func (m *manager) getContainer(containerName string) (*containerData, error) {
-	m.containersLock.RLock()
-	defer m.containersLock.RUnlock()
-	cont, ok := m.containers[namespacedContainerName{Name: containerName}]
+	v, ok := m.containers.Load(namespacedContainerName{Name: containerName})
 	if !ok {
 		return nil, fmt.Errorf("unknown container %q", containerName)
 	}
-	return cont, nil
+	return v.(*containerData), nil
 }
 
 func (m *manager) getSubcontainers(containerName string) map[string]*containerData {
 	matchedName := path.Join(containerName, "/")
-
-	m.containersLock.RLock()
-	defer m.containersLock.RUnlock()
-
-	containersMap := make(map[string]*containerData, len(m.containers))
+	containersMap := make(map[string]*containerData)
 
 	// Get all the unique subcontainers of the specified container
-	for _, cont := range m.containers {
+	m.containers.Range(func(_, value any) bool {
+		cont := value.(*containerData)
 		if cont == nil {
-			continue
+			return true
 		}
 		name := cont.info.Name
 		if name == containerName || strings.HasPrefix(name, matchedName) {
 			containersMap[name] = cont
 		}
-	}
+		return true
+	})
 	return containersMap
 }
 
@@ -604,16 +594,20 @@ func (m *manager) SubcontainersInfo(containerName string, query *info.ContainerI
 }
 
 func (m *manager) getAllNamespacedContainers(ns string) map[string]*containerData {
-	m.containersLock.RLock()
-	defer m.containersLock.RUnlock()
-	containers := make(map[string]*containerData, len(m.containers))
+	containers := make(map[string]*containerData)
 
 	// Get containers in a namespace.
-	for name, cont := range m.containers {
+	m.containers.Range(func(key, value any) bool {
+		name := key.(namespacedContainerName)
+		cont := value.(*containerData)
+		if cont == nil {
+			return true
+		}
 		if name.Namespace == ns {
 			containers[cont.info.Name] = cont
 		}
-	}
+		return true
+	})
 	return containers
 }
 
@@ -623,30 +617,33 @@ func (m *manager) AllDockerContainers(query *info.ContainerInfoRequest) (map[str
 }
 
 func (m *manager) namespacedContainer(containerName string, ns string) (*containerData, error) {
-	m.containersLock.RLock()
-	defer m.containersLock.RUnlock()
-
 	// Check for the container in the namespace.
-	cont, ok := m.containers[namespacedContainerName{
-		Namespace: ns,
-		Name:      containerName,
-	}]
+	if v, ok := m.containers.Load(namespacedContainerName{Namespace: ns, Name: containerName}); ok {
+		return v.(*containerData), nil
+	}
 
 	// Look for container by short prefix name if no exact match found.
-	if !ok {
-		for contName, c := range m.containers {
-			if contName.Namespace == ns && strings.HasPrefix(contName.Name, containerName) {
-				if cont == nil {
-					cont = c
-				} else {
-					return nil, fmt.Errorf("unable to find container in %q namespace. Container %q is not unique", ns, containerName)
-				}
+	var cont *containerData
+	var err error
+	m.containers.Range(func(key, value any) bool {
+		contName := key.(namespacedContainerName)
+		if contName.Namespace == ns && strings.HasPrefix(contName.Name, containerName) {
+			if cont == nil {
+				cont = value.(*containerData)
+			} else {
+				err = fmt.Errorf("unable to find container in %q namespace. Container %q is not unique", ns, containerName)
+				return false // stop iteration
 			}
 		}
+		return true
+	})
 
-		if cont == nil {
-			return nil, fmt.Errorf("unable to find container %q in %q namespace", containerName, ns)
-		}
+	if err != nil {
+		return nil, err
+	}
+
+	if cont == nil {
+		return nil, fmt.Errorf("unable to find container %q in %q namespace", containerName, ns)
 	}
 
 	return cont, nil
@@ -839,14 +836,7 @@ func (m *manager) GetVersionInfo() (*info.VersionInfo, error) {
 }
 
 func (m *manager) Exists(containerName string) bool {
-	m.containersLock.RLock()
-	defer m.containersLock.RUnlock()
-
-	namespacedName := namespacedContainerName{
-		Name: containerName,
-	}
-
-	_, ok := m.containers[namespacedName]
+	_, ok := m.containers.Load(namespacedContainerName{Name: containerName})
 	return ok
 }
 
@@ -906,19 +896,12 @@ func (m *manager) registerCollectors(collectorConfigs map[string]string, cont *c
 
 // Create a container.
 func (m *manager) createContainer(containerName string, watchSource watcher.ContainerWatchSource) error {
-	m.containersLock.Lock()
-	defer m.containersLock.Unlock()
-
-	return m.createContainerLocked(containerName, watchSource)
-}
-
-func (m *manager) createContainerLocked(containerName string, watchSource watcher.ContainerWatchSource) error {
 	namespacedName := namespacedContainerName{
 		Name: containerName,
 	}
 
 	// Check that the container didn't already exist.
-	if _, ok := m.containers[namespacedName]; ok {
+	if _, ok := m.containers.Load(namespacedName); ok {
 		return nil
 	}
 
@@ -972,12 +955,12 @@ func (m *manager) createContainerLocked(containerName string, watchSource watche
 	}
 
 	// Add the container name and all its aliases. The aliases must be within the namespace of the factory.
-	m.containers[namespacedName] = cont
+	m.containers.Store(namespacedName, cont)
 	for _, alias := range cont.info.Aliases {
-		m.containers[namespacedContainerName{
+		m.containers.Store(namespacedContainerName{
 			Namespace: cont.info.Namespace,
 			Name:      alias,
-		}] = cont
+		}, cont)
 	}
 
 	klog.V(3).Infof("Added container: %q (aliases: %v, namespace: %q)", containerName, cont.info.Aliases, cont.info.Namespace)
@@ -1006,21 +989,15 @@ func (m *manager) createContainerLocked(containerName string, watchSource watche
 }
 
 func (m *manager) destroyContainer(containerName string) error {
-	m.containersLock.Lock()
-	defer m.containersLock.Unlock()
-
-	return m.destroyContainerLocked(containerName)
-}
-
-func (m *manager) destroyContainerLocked(containerName string) error {
 	namespacedName := namespacedContainerName{
 		Name: containerName,
 	}
-	cont, ok := m.containers[namespacedName]
+	v, ok := m.containers.Load(namespacedName)
 	if !ok {
 		// Already destroyed, done.
 		return nil
 	}
+	cont := v.(*containerData)
 
 	// Tell the container to stop.
 	err := cont.Stop()
@@ -1029,9 +1006,9 @@ func (m *manager) destroyContainerLocked(containerName string) error {
 	}
 
 	// Remove the container from our records (and all its aliases).
-	delete(m.containers, namespacedName)
+	m.containers.Delete(namespacedName)
 	for _, alias := range cont.info.Aliases {
-		delete(m.containers, namespacedContainerName{
+		m.containers.Delete(namespacedContainerName{
 			Namespace: cont.info.Namespace,
 			Name:      alias,
 		})
@@ -1058,14 +1035,11 @@ func (m *manager) destroyContainerLocked(containerName string) error {
 // Detect all containers that have been added or deleted from the specified container.
 func (m *manager) getContainersDiff(containerName string) (added []info.ContainerReference, removed []info.ContainerReference, err error) {
 	// Get all subcontainers recursively.
-	m.containersLock.RLock()
-	cont, ok := m.containers[namespacedContainerName{
-		Name: containerName,
-	}]
-	m.containersLock.RUnlock()
+	v, ok := m.containers.Load(namespacedContainerName{Name: containerName})
 	if !ok {
 		return nil, nil, fmt.Errorf("failed to find container %q while checking for new containers", containerName)
 	}
+	cont := v.(*containerData)
 	allContainers, err := cont.handler.ListContainers(container.ListRecursive)
 
 	if err != nil {
@@ -1073,24 +1047,25 @@ func (m *manager) getContainersDiff(containerName string) (added []info.Containe
 	}
 	allContainers = append(allContainers, info.ContainerReference{Name: containerName})
 
-	m.containersLock.RLock()
-	defer m.containersLock.RUnlock()
-
 	// Determine which were added and which were removed.
 	allContainersSet := make(map[string]*containerData)
-	for name, d := range m.containers {
+	m.containers.Range(func(key, value any) bool {
+		name := key.(namespacedContainerName)
+		d := value.(*containerData)
+		if d == nil {
+			return true
+		}
 		// Only add the canonical name.
 		if d.info.Name == name.Name {
 			allContainersSet[name.Name] = d
 		}
-	}
+		return true
+	})
 
 	// Added containers
 	for _, c := range allContainers {
 		delete(allContainersSet, c.Name)
-		_, ok := m.containers[namespacedContainerName{
-			Name: c.Name,
-		}]
+		_, ok := m.containers.Load(namespacedContainerName{Name: c.Name})
 		if !ok {
 			added = append(added, c)
 		}
@@ -1321,16 +1296,14 @@ func (m *manager) DebugInfo() map[string][]string {
 	debugInfo := container.DebugInfo()
 
 	// Get unique containers.
-	var conts map[*containerData]struct{}
-	func() {
-		m.containersLock.RLock()
-		defer m.containersLock.RUnlock()
-
-		conts = make(map[*containerData]struct{}, len(m.containers))
-		for _, c := range m.containers {
-			conts[c] = struct{}{}
+	conts := make(map[*containerData]struct{})
+	m.containers.Range(func(_, value any) bool {
+		cont := value.(*containerData)
+		if cont != nil {
+			conts[cont] = struct{}{}
 		}
-	}()
+		return true
+	})
 
 	// List containers.
 	lines := make([]string, 0, len(conts))

--- a/manager/manager.go
+++ b/manager/manager.go
@@ -244,8 +244,40 @@ type namespacedContainerName struct {
 	Name string
 }
 
+// containerMap is a type-safe wrapper around sync.Map for storing containerData
+// keyed by namespacedContainerName.
+type containerMap struct {
+	m sync.Map
+}
+
+// Load returns the containerData for the given name, or nil if not found.
+func (c *containerMap) Load(name namespacedContainerName) (*containerData, bool) {
+	v, ok := c.m.Load(name)
+	if !ok {
+		return nil, false
+	}
+	return v.(*containerData), true
+}
+
+// Store stores the containerData for the given name.
+func (c *containerMap) Store(name namespacedContainerName, data *containerData) {
+	c.m.Store(name, data)
+}
+
+// Delete removes the containerData for the given name.
+func (c *containerMap) Delete(name namespacedContainerName) {
+	c.m.Delete(name)
+}
+
+// Range calls f for each container in the map. If f returns false, iteration stops.
+func (c *containerMap) Range(f func(name namespacedContainerName, data *containerData) bool) {
+	c.m.Range(func(key, value any) bool {
+		return f(key.(namespacedContainerName), value.(*containerData))
+	})
+}
+
 type manager struct {
-	containers               sync.Map // namespacedContainerName -> *containerData
+	containers               containerMap
 	memoryCache              *memory.InMemoryCache
 	fsInfo                   fs.FsInfo
 	sysFs                    sysfs.SysFs
@@ -361,8 +393,7 @@ func (m *manager) Stop() error {
 }
 
 func (m *manager) destroyCollectors() {
-	m.containers.Range(func(_, value any) bool {
-		container := value.(*containerData)
+	m.containers.Range(func(_ namespacedContainerName, container *containerData) bool {
 		if container == nil {
 			return true
 		}
@@ -429,11 +460,11 @@ func (m *manager) globalHousekeeping(quit chan error) {
 
 func (m *manager) getContainerData(containerName string) (*containerData, error) {
 	// Ensure we have the container.
-	v, ok := m.containers.Load(namespacedContainerName{Name: containerName})
+	cont, ok := m.containers.Load(namespacedContainerName{Name: containerName})
 	if !ok {
 		return nil, fmt.Errorf("unknown container %q", containerName)
 	}
-	return v.(*containerData), nil
+	return cont, nil
 }
 
 func (m *manager) GetDerivedStats(containerName string, options v2.RequestOptions) (map[string]v2.DerivedStats, error) {
@@ -557,11 +588,11 @@ func (m *manager) containerDataToContainerInfo(cont *containerData, query *info.
 }
 
 func (m *manager) getContainer(containerName string) (*containerData, error) {
-	v, ok := m.containers.Load(namespacedContainerName{Name: containerName})
+	cont, ok := m.containers.Load(namespacedContainerName{Name: containerName})
 	if !ok {
 		return nil, fmt.Errorf("unknown container %q", containerName)
 	}
-	return v.(*containerData), nil
+	return cont, nil
 }
 
 func (m *manager) getSubcontainers(containerName string) map[string]*containerData {
@@ -569,8 +600,7 @@ func (m *manager) getSubcontainers(containerName string) map[string]*containerDa
 	containersMap := make(map[string]*containerData)
 
 	// Get all the unique subcontainers of the specified container
-	m.containers.Range(func(_, value any) bool {
-		cont := value.(*containerData)
+	m.containers.Range(func(_ namespacedContainerName, cont *containerData) bool {
 		if cont == nil {
 			return true
 		}
@@ -597,9 +627,7 @@ func (m *manager) getAllNamespacedContainers(ns string) map[string]*containerDat
 	containers := make(map[string]*containerData)
 
 	// Get containers in a namespace.
-	m.containers.Range(func(key, value any) bool {
-		name := key.(namespacedContainerName)
-		cont := value.(*containerData)
+	m.containers.Range(func(name namespacedContainerName, cont *containerData) bool {
 		if cont == nil {
 			return true
 		}
@@ -618,18 +646,17 @@ func (m *manager) AllDockerContainers(query *info.ContainerInfoRequest) (map[str
 
 func (m *manager) namespacedContainer(containerName string, ns string) (*containerData, error) {
 	// Check for the container in the namespace.
-	if v, ok := m.containers.Load(namespacedContainerName{Namespace: ns, Name: containerName}); ok {
-		return v.(*containerData), nil
+	if cont, ok := m.containers.Load(namespacedContainerName{Namespace: ns, Name: containerName}); ok {
+		return cont, nil
 	}
 
 	// Look for container by short prefix name if no exact match found.
 	var cont *containerData
 	var err error
-	m.containers.Range(func(key, value any) bool {
-		contName := key.(namespacedContainerName)
-		if contName.Namespace == ns && strings.HasPrefix(contName.Name, containerName) {
+	m.containers.Range(func(name namespacedContainerName, c *containerData) bool {
+		if name.Namespace == ns && strings.HasPrefix(name.Name, containerName) {
 			if cont == nil {
-				cont = value.(*containerData)
+				cont = c
 			} else {
 				err = fmt.Errorf("unable to find container in %q namespace. Container %q is not unique", ns, containerName)
 				return false // stop iteration
@@ -992,12 +1019,11 @@ func (m *manager) destroyContainer(containerName string) error {
 	namespacedName := namespacedContainerName{
 		Name: containerName,
 	}
-	v, ok := m.containers.Load(namespacedName)
+	cont, ok := m.containers.Load(namespacedName)
 	if !ok {
 		// Already destroyed, done.
 		return nil
 	}
-	cont := v.(*containerData)
 
 	// Tell the container to stop.
 	err := cont.Stop()
@@ -1035,11 +1061,10 @@ func (m *manager) destroyContainer(containerName string) error {
 // Detect all containers that have been added or deleted from the specified container.
 func (m *manager) getContainersDiff(containerName string) (added []info.ContainerReference, removed []info.ContainerReference, err error) {
 	// Get all subcontainers recursively.
-	v, ok := m.containers.Load(namespacedContainerName{Name: containerName})
+	cont, ok := m.containers.Load(namespacedContainerName{Name: containerName})
 	if !ok {
 		return nil, nil, fmt.Errorf("failed to find container %q while checking for new containers", containerName)
 	}
-	cont := v.(*containerData)
 	allContainers, err := cont.handler.ListContainers(container.ListRecursive)
 
 	if err != nil {
@@ -1049,15 +1074,13 @@ func (m *manager) getContainersDiff(containerName string) (added []info.Containe
 
 	// Determine which were added and which were removed.
 	allContainersSet := make(map[string]*containerData)
-	m.containers.Range(func(key, value any) bool {
-		name := key.(namespacedContainerName)
-		d := value.(*containerData)
-		if d == nil {
+	m.containers.Range(func(name namespacedContainerName, cont *containerData) bool {
+		if cont == nil {
 			return true
 		}
 		// Only add the canonical name.
-		if d.info.Name == name.Name {
-			allContainersSet[name.Name] = d
+		if cont.info.Name == name.Name {
+			allContainersSet[name.Name] = cont
 		}
 		return true
 	})
@@ -1297,8 +1320,7 @@ func (m *manager) DebugInfo() map[string][]string {
 
 	// Get unique containers.
 	conts := make(map[*containerData]struct{})
-	m.containers.Range(func(_, value any) bool {
-		cont := value.(*containerData)
+	m.containers.Range(func(_ namespacedContainerName, cont *containerData) bool {
 		if cont != nil {
 			conts[cont] = struct{}{}
 		}

--- a/manager/manager_bench_test.go
+++ b/manager/manager_bench_test.go
@@ -1,0 +1,163 @@
+// Copyright 2025 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package manager
+
+import (
+	"fmt"
+	"sync"
+	"testing"
+)
+
+// Benchmark concurrent reads on sync.Map
+func BenchmarkSyncMapConcurrentReads(b *testing.B) {
+	var m sync.Map
+
+	for i := 0; i < 1000; i++ {
+		key := namespacedContainerName{Name: fmt.Sprintf("/container/%d", i)}
+		m.Store(key, &containerData{})
+	}
+
+	b.ResetTimer()
+	b.RunParallel(func(pb *testing.PB) {
+		i := 0
+		for pb.Next() {
+			key := namespacedContainerName{Name: fmt.Sprintf("/container/%d", i%1000)}
+			m.Load(key)
+			i++
+		}
+	})
+}
+
+// Benchmark concurrent reads on RWMutex and map
+func BenchmarkRWMutexMapConcurrentReads(b *testing.B) {
+	var mu sync.RWMutex
+	m := make(map[namespacedContainerName]*containerData)
+
+	for i := 0; i < 1000; i++ {
+		key := namespacedContainerName{Name: fmt.Sprintf("/container/%d", i)}
+		m[key] = &containerData{}
+	}
+
+	b.ResetTimer()
+	b.RunParallel(func(pb *testing.PB) {
+		i := 0
+		for pb.Next() {
+			key := namespacedContainerName{Name: fmt.Sprintf("/container/%d", i%1000)}
+			mu.RLock()
+			_ = m[key]
+			mu.RUnlock()
+			i++
+		}
+	})
+}
+
+// Benchmark iteration with sync.Map
+func BenchmarkSyncMapIteration(b *testing.B) {
+	var m sync.Map
+
+	for i := 0; i < 1000; i++ {
+		key := namespacedContainerName{Name: fmt.Sprintf("/container/%d", i)}
+		m.Store(key, &containerData{})
+	}
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		count := 0
+		m.Range(func(_, _ any) bool {
+			count++
+			return true
+		})
+	}
+}
+
+// Benchmark iteration with RWMutex and map
+func BenchmarkRWMutexMapIteration(b *testing.B) {
+	var mu sync.RWMutex
+	m := make(map[namespacedContainerName]*containerData)
+
+	for i := 0; i < 1000; i++ {
+		key := namespacedContainerName{Name: fmt.Sprintf("/container/%d", i)}
+		m[key] = &containerData{}
+	}
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		mu.RLock()
+		count := 0
+		for range m {
+			count++
+		}
+		mu.RUnlock()
+	}
+}
+
+// Benchmark mixed read/write with sync.Map
+func BenchmarkSyncMapMixedReadWrite(b *testing.B) {
+	var m sync.Map
+
+	for i := 0; i < 1000; i++ {
+		key := namespacedContainerName{Name: fmt.Sprintf("/container/%d", i)}
+		m.Store(key, &containerData{})
+	}
+
+	b.ResetTimer()
+	b.RunParallel(func(pb *testing.PB) {
+		i := 0
+		for pb.Next() {
+			if i%100 == 0 {
+				// 1% writes
+				key := namespacedContainerName{Name: fmt.Sprintf("/container/new/%d", i)}
+				m.Store(key, &containerData{})
+			} else {
+				// 99% reads
+				key := namespacedContainerName{Name: fmt.Sprintf("/container/%d", i%1000)}
+				m.Load(key)
+			}
+			i++
+		}
+	})
+}
+
+// Benchmark mixed read/write with RWMutex and map
+func BenchmarkRWMutexMapMixedReadWrite(b *testing.B) {
+	var mu sync.RWMutex
+	m := make(map[namespacedContainerName]*containerData)
+
+	for i := 0; i < 1000; i++ {
+		key := namespacedContainerName{Name: fmt.Sprintf("/container/%d", i)}
+		m[key] = &containerData{}
+	}
+
+	b.ResetTimer()
+	b.RunParallel(func(pb *testing.PB) {
+		i := 0
+		for pb.Next() {
+			if i%100 == 0 {
+				// 1% writes
+				key := namespacedContainerName{Name: fmt.Sprintf("/container/new/%d", i)}
+				mu.Lock()
+				m[key] = &containerData{}
+				mu.Unlock()
+			} else {
+				// 99% reads
+				key := namespacedContainerName{Name: fmt.Sprintf("/container/%d", i%1000)}
+				mu.RLock()
+				_ = m[key]
+				mu.RUnlock()
+			}
+			i++
+		}
+	})
+}

--- a/manager/manager_test.go
+++ b/manager/manager_test.go
@@ -383,8 +383,8 @@ func TestGetContainerInfoV2Failure(t *testing.T) {
 	handlerMap[failing].On("GetSpec").Return(info.ContainerSpec{}, mockErr)
 	handlerMap[failing].On("Exists").Return(true)
 	// Force GetSpec by resetting infoLastUpdatedTime to zero.
-	if v, ok := m.containers.Load(namespacedContainerName{Name: failing}); ok {
-		v.(*containerData).infoLastUpdatedTime.Store(0)
+	if cont, ok := m.containers.Load(namespacedContainerName{Name: failing}); ok {
+		cont.infoLastUpdatedTime.Store(0)
 	}
 
 	infos, err := m.GetContainerInfoV2("/", options)

--- a/manager/manager_test.go
+++ b/manager/manager_test.go
@@ -54,7 +54,6 @@ func createManagerAndAddContainers(
 ) *manager {
 	container.ClearContainerHandlerFactories()
 	mif := &manager{
-		containers:   make(map[namespacedContainerName]*containerData),
 		quitChannels: make([]chan error, 0, 2),
 		memoryCache:  memoryCache,
 	}
@@ -69,15 +68,15 @@ func createManagerAndAddContainers(
 		if err != nil {
 			t.Fatal(err)
 		}
-		mif.containers[namespacedContainerName{
+		mif.containers.Store(namespacedContainerName{
 			Name: name,
-		}] = cont
+		}, cont)
 		// Add Docker containers under their namespace.
 		if strings.HasPrefix(name, "/docker") {
-			mif.containers[namespacedContainerName{
+			mif.containers.Store(namespacedContainerName{
 				Namespace: DockerNamespace,
 				Name:      strings.TrimPrefix(name, "/docker/"),
-			}] = cont
+			}, cont)
 		}
 		f(mockHandler)
 	}
@@ -93,7 +92,6 @@ func createManagerAndAddSubContainers(
 ) *manager {
 	container.ClearContainerHandlerFactories()
 	mif := &manager{
-		containers:   make(map[namespacedContainerName]*containerData),
 		quitChannels: make([]chan error, 0, 2),
 		memoryCache:  memoryCache,
 	}
@@ -132,15 +130,15 @@ func createManagerAndAddSubContainers(
 		if err != nil {
 			t.Fatal(err)
 		}
-		mif.containers[namespacedContainerName{
+		mif.containers.Store(namespacedContainerName{
 			Name: name,
-		}] = cont
+		}, cont)
 		// Add Docker containers under their namespace.
 		if strings.HasPrefix(name, "/docker") {
-			mif.containers[namespacedContainerName{
+			mif.containers.Store(namespacedContainerName{
 				Namespace: DockerNamespace,
 				Name:      strings.TrimPrefix(name, "/docker/"),
-			}] = cont
+			}, cont)
 		}
 		f(mockHandler)
 	}

--- a/manager/manager_test.go
+++ b/manager/manager_test.go
@@ -384,7 +384,10 @@ func TestGetContainerInfoV2Failure(t *testing.T) {
 	assert.NoError(t, err) // Use up default GetSpec call, and replace below
 	handlerMap[failing].On("GetSpec").Return(info.ContainerSpec{}, mockErr)
 	handlerMap[failing].On("Exists").Return(true)
-	m.containers[namespacedContainerName{Name: failing}].infoLastUpdatedTime = time.Time{} // Force GetSpec.
+	// Force GetSpec by resetting infoLastUpdatedTime to zero.
+	if v, ok := m.containers.Load(namespacedContainerName{Name: failing}); ok {
+		v.(*containerData).infoLastUpdatedTime.Store(0)
+	}
 
 	infos, err := m.GetContainerInfoV2("/", options)
 	if err == nil {


### PR DESCRIPTION
This PR picks the following upstream changes:

- https://github.com/google/cadvisor/pull/3756
- https://github.com/google/cadvisor/pull/3762

In the k8s-e2e-conformance-aws test from o/k, we got the following results:

|| Before | After |
|-----|---------|---------------|
|P50|0.28|0.30|
|P90|0.81|0.66|
|P99|10|1.7|
|avg|0.96|0.32|

Each of these values are measured in seconds at their peak.